### PR TITLE
Match entity text

### DIFF
--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -23,8 +23,6 @@ NUMBER_START = re.compile(r"^(\s*-?[0-9]+)")
 
 NON_WORD_START = re.compile(r"^\W+")
 
-NON_WORD_ALL = re.compile(r"^\W+$")
-
 
 class HassilError(Exception):
     """Base class for hassil errors"""

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -48,6 +48,9 @@ class MatchEntity:
     value: Any
     """Value of the entity."""
 
+    text: str
+    """Original value text."""
+
 
 @dataclass
 class MatchContext:
@@ -212,7 +215,7 @@ def recognize(
                         # Add fixed entities
                         for slot_name, slot_value in intent_data.slots.items():
                             maybe_match_context.entities.append(
-                                MatchEntity(name=slot_name, value=slot_value)
+                                MatchEntity(name=slot_name, value=slot_value, text="")
                             )
 
                         # Return the first match
@@ -361,7 +364,9 @@ def match_expression(
                     for value_context in value_contexts:
                         value_context.entities.append(
                             MatchEntity(
-                                name=list_ref.slot_name, value=slot_value.value_out
+                                name=list_ref.slot_name,
+                                value=slot_value.value_out,
+                                text=context.text,
                             )
                         )
 
@@ -391,7 +396,11 @@ def match_expression(
 
                     if in_range:
                         context.entities.append(
-                            MatchEntity(name=list_ref.slot_name, value=word_number)
+                            MatchEntity(
+                                name=list_ref.slot_name,
+                                value=word_number,
+                                text=context.text,
+                            )
                         )
 
                         yield dataclasses.replace(

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -311,3 +311,53 @@ def test_response_key() -> None:
     result = recognize("this is a test", intents)
     assert result is not None
     assert result.response == "test_response"
+
+
+def test_entity_text() -> None:
+    """Ensure original text is returned as well as substituted list value"""
+    yaml_text = """
+    language: "en"
+    intents:
+      TestIntent:
+        data:
+          - sentences:
+              - "run test {name}"
+    lists:
+      name:
+        values:
+          - in: "alpha"
+            out: "A"
+    """
+
+    with io.StringIO(yaml_text) as test_file:
+        intents = Intents.from_yaml(test_file)
+
+    result = recognize("run test alpha", intents)
+    assert result is not None
+    assert result.entities["name"].value == "A"
+    assert result.entities["name"].text.strip() == "alpha"
+
+
+def test_number_text() -> None:
+    """Ensure original text is returned as well as substituted number"""
+    yaml_text = """
+    language: "en"
+    intents:
+      TestIntent:
+        data:
+          - sentences:
+              - "set {percentage}"
+    lists:
+      percentage:
+        range:
+          from: 0
+          to: 100
+    """
+
+    with io.StringIO(yaml_text) as test_file:
+        intents = Intents.from_yaml(test_file)
+
+    result = recognize("set 50%", intents)
+    assert result is not None
+    assert result.entities["percentage"].value == 50
+    assert result.entities["percentage"].text.strip() == "50%"


### PR DESCRIPTION
Add `.text` to `MatchEntity` so you can retrieve the original text as well as the substituted value.