### PR TITLE
exclude 'tests' from installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author="Michael Hansen",
     author_email="mike@rhasspy.org",
     license="Apache-2.0",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests','tests.*'),
     package_data={
         "hassil": ["VERSION", "py.typed"],
     },


### PR DESCRIPTION
```
2023-02-04 16:44:28,012 gpep517 INFO The backend produced /var/tmp/portage/dev-python/hassil-0.2.6/work/hassil-0.2.6-python3_10/wheel/hassil-0.2.6-py3-none-any.whl
 *   Installing hassil-0.2.6-py3-none-any.whl to /var/tmp/portage/dev-python/hassil-0.2.6/work/hassil-0.2.6-python3_10/install
gpep517 install-wheel --destdir=/var/tmp/portage/dev-python/hassil-0.2.6/work/hassil-0.2.6-python3_10/install --interpreter=/usr/bin/python3.10 --prefix=/usr --optimize=all /var/tmp/portage/dev-python/hassil-0.2.6/work/hassil-0.2.6-python3_10/wheel/hassil-0.2.6-py3-none-any.whl
2023-02-04 16:44:28,174 gpep517 INFO Installing /var/tmp/portage/dev-python/hassil-0.2.6/work/hassil-0.2.6-python3_10/wheel/hassil-0.2.6-py3-none-any.whl into /var/tmp/portage/dev-python/hassil-0.2.6/work/hassil-0.2.6-python3_10/install
2023-02-04 16:44:28,288 gpep517 INFO Installation complete
>>> Source compiled.
>>> Test phase [not enabled]: dev-python/hassil-0.2.6

>>> Install dev-python/hassil-0.2.6 into /var/tmp/portage/dev-python/hassil-0.2.6/image
 * python3_10: running distutils-r1_run_phase distutils-r1_python_install
 * ERROR: dev-python/hassil-0.2.6::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
```