### PR TITLE
Local expansion rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Uses a custom parser written in Python.
   * Refers to a pre-defined list of values in YAML (`lists`)
 * Expansion Rules
   * `<rule_name>`
-  * Refers to a pre-defined expansion rule in YAML (`expansion_rules`)
+  * Refers to a pre-defined expansion rule in YAML (`expansion_rules`), either global or local (particular to the intent to which the sentence refers)
 
 
 ## YAML Format
@@ -100,6 +100,9 @@ intents:
         excludes_context:
           # Must NOT be present in match context
           <name>: <value or list>
+        expansion_rules:
+          # Expansion rules which only apply to the intent, referenced as <rule_name>
+          <rule_name>: <sentence template>
 
 # Optional lists of items that become alternatives in sentence templates
 lists:

--- a/hassil/intents.py
+++ b/hassil/intents.py
@@ -43,6 +43,9 @@ class IntentData:
     excludes_context: Dict[str, Any] = field(default_factory=dict)
     """Context items that must not be present for match to be successful."""
 
+    expansion_rules: Dict[str, Sentence] = field(default_factory=dict)
+    """Local expansion rules in the context of a single intent."""
+
     @cached_property
     def sentences(self) -> List[Sentence]:
         """Sentence templates that match this intent."""
@@ -236,6 +239,12 @@ class Intents:
                             slots=data_dict.get("slots", {}),
                             requires_context=data_dict.get("requires_context", {}),
                             excludes_context=data_dict.get("excludes_context", {}),
+                            expansion_rules={
+                                rule_name: parse_sentence(rule_body, keep_text=True)
+                                for rule_name, rule_body in data_dict.get(
+                                    "expansion_rules", {}
+                                ).items()
+                            },
                             response=data_dict.get("response"),
                         )
                         for data_dict in intent_dict["data"]

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -245,6 +245,15 @@ def recognize_all(
                 if skip_data:
                     continue
 
+            local_settings = MatchSettings(
+                slot_lists=settings.slot_lists,
+                expansion_rules={
+                    **settings.expansion_rules,
+                    **intent_data.expansion_rules,
+                },
+                ignore_whitespace=settings.ignore_whitespace,
+            )
+
             # Check each sentence template
             for intent_sentence in intent_data.sentences:
                 # Create initial context
@@ -253,7 +262,7 @@ def recognize_all(
                     intent_context=intent_context,
                 )
                 maybe_match_contexts = match_expression(
-                    settings, match_context, intent_sentence
+                    local_settings, match_context, intent_sentence
                 )
                 for maybe_match_context in maybe_match_contexts:
                     if not maybe_match_context.is_match:


### PR DESCRIPTION
We could easily have reusable sentences if we were able to define or overwrite some expansion rules locally. Imagine the following scenario:

Most nominal binary sensor sentences sound something like

```
- is [<some_particular_device_class>] <name> {bs_device_class_state:state} [in <area>]
- is <name> [<some_particular_device_class>] {bs_device_clas0s_state:state} [in <area>]
- is [<some_particular_device_class>] <name> in <area> {bs_device_class_state:state}
- is <name> [<some_particular_device_class>] in <area> {bs_device_class_state:state}
```

but it's hard to write those variations for each device_class.

Imagine the following expansion rule:

```
is_name_state_in_area: "is (<name> [<class>] | <class> <name>) (<state> [in <area>]|in <area> <state>)"
```

The `<name>` and `<area>` expansion rules are defined globally. But if, for each device class, you could do something like

```
intents:
  HassGetState:
    data:
      - expansion_rules:
          state: "{bs_battery_states:state}"
          class: "battery"
        sentences:
          - "<is_name_state_in_area>"
        response: one_yesno
        requires_context:
          domain: binary_sensor
          device_class: battery
        slots:
          domain: binary_sensor
          device_class: battery
      - expansion_rules:
          state: "{bs_gas_states:state}"
          class: "gas sensor"
        sentences:
          - "<is_name_state_in_area>"
        response: one_yesno
        requires_context:
          domain: binary_sensor
          device_class: gas
        slots:
          domain: binary_sensor
          device_class: gas
```

that would make the sentences far easier to write and maintain.