### PR TITLE
Remove leftover antl4r and dataclasses-json references

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ The Home Assistant Intent Language (HassIL) parser for [intents](https://github.
 
 ## Dependencies
 
-* antlr4-python3-runtime
 * PyYAML
-* dataclasses-json
 
 
 ## Installation

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,9 +4,6 @@
 [mypy-setuptools.*]
 ignore_missing_imports = True
 
-[mypy-antlr4.*]
-ignore_missing_imports = True
-
 [mypy-pytest.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
The dependency on those libraries was removed in the 1.0 release.