### PR TITLE
Multiple filters first draft

### DIFF
--- a/hassil/intents.py
+++ b/hassil/intents.py
@@ -28,6 +28,9 @@ class ResponseType(str, Enum):
 class IntentFilter:
     """A single match filter consisting of required and excluded context and slots."""
 
+    id: str
+    """A unique indentifier of a filter."""
+
     slots: Dict[str, Any] = field(default_factory=dict)
     """Slot values that are assumed if intent is matched."""
 
@@ -246,6 +249,7 @@ class Intents:
                             sentence_texts=data_dict["sentences"],
                             filters=[
                                 IntentFilter(
+                                    id=f"{intent_name}:{data_idx}:{filter_idx}",
                                     slots=intent_filter.get("slots", {}),
                                     requires_context=intent_filter.get(
                                         "requires_context", {}
@@ -254,11 +258,12 @@ class Intents:
                                         "excludes_context", {}
                                     ),
                                 )
-                                for intent_filter in data_dict.get("filters", [])
+                                for filter_idx, intent_filter in enumerate(data_dict.get("filters"))
                             ]
                             if data_dict.get("filters")
                             else [
                                 IntentFilter(
+                                    id=f"{intent_name}:{data_idx}:0",
                                     slots=data_dict.get("slots", {}),
                                     requires_context=data_dict.get(
                                         "requires_context", {}
@@ -276,7 +281,7 @@ class Intents:
                             },
                             response=data_dict.get("response"),
                         )
-                        for data_dict in intent_dict["data"]
+                        for data_idx, data_dict in enumerate(intent_dict["data"])
                     ],
                 )
                 for intent_name, intent_dict in input_dict["intents"].items()

--- a/hassil/intents.py
+++ b/hassil/intents.py
@@ -28,9 +28,6 @@ class ResponseType(str, Enum):
 class IntentFilter:
     """A single match filter consisting of required and excluded context and slots."""
 
-    id: str
-    """A unique indentifier of a filter."""
-
     slots: Dict[str, Any] = field(default_factory=dict)
     """Slot values that are assumed if intent is matched."""
 
@@ -249,7 +246,6 @@ class Intents:
                             sentence_texts=data_dict["sentences"],
                             filters=[
                                 IntentFilter(
-                                    id=f"{intent_name}:{data_idx}:{filter_idx}",
                                     slots=intent_filter.get("slots", {}),
                                     requires_context=intent_filter.get(
                                         "requires_context", {}
@@ -258,14 +254,11 @@ class Intents:
                                         "excludes_context", {}
                                     ),
                                 )
-                                for filter_idx, intent_filter in enumerate(
-                                    data_dict.get("filters")
-                                )
+                                for intent_filter in data_dict.get("filters")
                             ]
                             if data_dict.get("filters")
                             else [
                                 IntentFilter(
-                                    id=f"{intent_name}:{data_idx}:0",
                                     slots=data_dict.get("slots", {}),
                                     requires_context=data_dict.get(
                                         "requires_context", {}
@@ -283,7 +276,7 @@ class Intents:
                             },
                             response=data_dict.get("response"),
                         )
-                        for data_idx, data_dict in enumerate(intent_dict["data"])
+                        for data_dict in intent_dict["data"]
                     ],
                 )
                 for intent_name, intent_dict in input_dict["intents"].items()

--- a/hassil/intents.py
+++ b/hassil/intents.py
@@ -258,7 +258,9 @@ class Intents:
                                         "excludes_context", {}
                                     ),
                                 )
-                                for filter_idx, intent_filter in enumerate(data_dict.get("filters"))
+                                for filter_idx, intent_filter in enumerate(
+                                    data_dict.get("filters")
+                                )
                             ]
                             if data_dict.get("filters")
                             else [

--- a/hassil/intents.py
+++ b/hassil/intents.py
@@ -23,6 +23,7 @@ class ResponseType(str, Enum):
     NO_ENTITY = "no_entity"
     HANDLE_ERROR = "handle_error"
 
+
 @dataclass(frozen=True)
 class IntentFilter:
     """A single match filter consisting of required and excluded context and slots."""
@@ -35,6 +36,7 @@ class IntentFilter:
 
     excludes_context: Dict[str, Any] = field(default_factory=dict)
     """Context items that must not be present for match to be successful."""
+
 
 @dataclass(frozen=True)
 class IntentData:
@@ -245,15 +247,25 @@ class Intents:
                             filters=[
                                 IntentFilter(
                                     slots=intent_filter.get("slots", {}),
-                                    requires_context=intent_filter.get("requires_context", {}),
-                                    excludes_context=intent_filter.get("excludes_context", {}),
+                                    requires_context=intent_filter.get(
+                                        "requires_context", {}
+                                    ),
+                                    excludes_context=intent_filter.get(
+                                        "excludes_context", {}
+                                    ),
                                 )
                                 for intent_filter in data_dict.get("filters", [])
-                            ] if data_dict.get("filters") else [
+                            ]
+                            if data_dict.get("filters")
+                            else [
                                 IntentFilter(
                                     slots=data_dict.get("slots", {}),
-                                    requires_context=data_dict.get("requires_context", {}),
-                                    excludes_context=data_dict.get("excludes_context", {}),
+                                    requires_context=data_dict.get(
+                                        "requires_context", {}
+                                    ),
+                                    excludes_context=data_dict.get(
+                                        "excludes_context", {}
+                                    ),
                                 )
                             ],
                             expansion_rules={

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -101,6 +101,13 @@ class MatchContext:
         text = PUNCTUATION.sub("", self.text).strip()
         return not text
 
+@dataclass
+class RecognizeResultEntities:
+    entities: Dict[str, MatchEntity] = field(default_factory=dict)
+    """Matched entities mapped by name."""
+
+    entities_list: List[MatchEntity] = field(default_factory=list)
+    """Matched entities as a list (duplicates allowed)."""
 
 @dataclass
 class RecognizeResult:
@@ -112,11 +119,11 @@ class RecognizeResult:
     intent_data: IntentData
     """Matched intent data"""
 
-    entities: Dict[str, MatchEntity] = field(default_factory=dict)
-    """Matched entities mapped by name."""
+    entities: Dict[str, List[str]] = field(default_factory=dict)
+    """All matched entity values by entity name."""
 
-    entities_list: List[MatchEntity] = field(default_factory=list)
-    """Matched entities as a list (duplicates allowed)."""
+    entities_per_filter: Dict[str, RecognizeResultEntities] = field(default_factory=dict)
+    """Matched entities for each matched filter."""
 
     response: Optional[str] = None
     """Key for intent response."""

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -101,6 +101,7 @@ class MatchContext:
         text = PUNCTUATION.sub("", self.text).strip()
         return not text
 
+
 @dataclass
 class RecognizeResultEntities:
     entities: Dict[str, MatchEntity] = field(default_factory=dict)
@@ -111,6 +112,7 @@ class RecognizeResultEntities:
 
     context: Dict[str, Any] = field(default_factory=dict)
     """Context values acquired during matching."""
+
 
 @dataclass
 class RecognizeResult:
@@ -316,7 +318,9 @@ def recognize_all(
                                     break
 
                                 if (
-                                    isinstance(context_value, collections.abc.Collection)
+                                    isinstance(
+                                        context_value, collections.abc.Collection
+                                    )
                                     and not isinstance(context_value, str)
                                     and (actual_value in context_value)
                                 ):
@@ -341,12 +345,16 @@ def recognize_all(
                                     # Exact match to context value, except when context value is required and not provided
                                     continue
 
-                                if (context_value is None) and (actual_value is not None):
+                                if (context_value is None) and (
+                                    actual_value is not None
+                                ):
                                     # Any value matches, as long as it's set
                                     continue
 
                                 if (
-                                    isinstance(context_value, collections.abc.Collection)
+                                    isinstance(
+                                        context_value, collections.abc.Collection
+                                    )
                                     and not isinstance(context_value, str)
                                     and (actual_value in context_value)
                                 ):
@@ -360,7 +368,7 @@ def recognize_all(
                         if skip_match:
                             # No intent context matched, from any filter
                             continue
-                        
+
                         any_filter_matches = True
 
                         # Add fixed entities
@@ -368,7 +376,7 @@ def recognize_all(
                             maybe_match_context.entities.append(
                                 MatchEntity(name=slot_name, value=slot_value, text="")
                             )
-                        
+
                         # Store a new result
                         per_filter_result_entities.append(
                             RecognizeResultEntities(
@@ -377,13 +385,13 @@ def recognize_all(
                                     for entity in maybe_match_context.entities
                                 },
                                 entities_list=maybe_match_context.entities,
-                                context=maybe_match_context.intent_context
+                                context=maybe_match_context.intent_context,
                             )
                         )
 
                 if not any_filter_matches:
                     continue
-                        
+
                 # Return each match
                 response = default_response
                 if intent_data.response is not None:

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -18,7 +18,6 @@ from .expression import (
 from .intents import (
     Intent,
     IntentData,
-    IntentFilter,
     Intents,
     RangeSlotList,
     SlotList,
@@ -88,9 +87,6 @@ class MatchContext:
 
     intent_context: Dict[str, Any] = field(default_factory=dict)
     """Context items from outside or acquired during matching."""
-
-    matched_intent_filters: List[IntentFilter] = field(default_factory=list)
-    """The filters (slots and required/excluded context) that have produced a match"""
 
     is_start_of_word: bool = True
     """True if current text is the start of a word."""

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -15,14 +15,7 @@ from .expression import (
     SequenceType,
     TextChunk,
 )
-from .intents import (
-    Intent,
-    IntentData,
-    Intents,
-    RangeSlotList,
-    SlotList,
-    TextSlotList,
-)
+from .intents import Intent, IntentData, Intents, RangeSlotList, SlotList, TextSlotList
 from .util import normalize_text, normalize_whitespace
 
 NUMBER_START = re.compile(r"^(\s*-?[0-9]+)")

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -15,7 +15,15 @@ from .expression import (
     SequenceType,
     TextChunk,
 )
-from .intents import Intent, IntentData, IntentFilter, Intents, RangeSlotList, SlotList, TextSlotList
+from .intents import (
+    Intent,
+    IntentData,
+    IntentFilter,
+    Intents,
+    RangeSlotList,
+    SlotList,
+    TextSlotList,
+)
 from .util import normalize_text, normalize_whitespace
 
 NUMBER_START = re.compile(r"^(\s*-?[0-9]+)")
@@ -225,7 +233,7 @@ def recognize_all(
                             elif actual_value != required_value:
                                 filter_matches = False
                                 break
-                    
+
                     if filter_matches:
                         any_filter_matches = True
                         break
@@ -248,7 +256,7 @@ def recognize_all(
                             elif actual_value == excluded_value:
                                 filter_matches = False
                                 break
-                    
+
                     if filter_matches:
                         any_filter_matches = True
                         break
@@ -283,9 +291,9 @@ def recognize_all(
                     skip_match = True
 
                     for intent_filter in intent_data.filters:
-                        
+
                         filter_matches = True
-                        
+
                         # Verify excluded context
                         if intent_filter.excludes_context:
                             for (
@@ -301,7 +309,9 @@ def recognize_all(
                                     break
 
                                 if (
-                                    isinstance(context_value, collections.abc.Collection)
+                                    isinstance(
+                                        context_value, collections.abc.Collection
+                                    )
                                     and not isinstance(context_value, str)
                                     and (actual_value in context_value)
                                 ):
@@ -326,12 +336,16 @@ def recognize_all(
                                     # Exact match to context value, except when context value is required and not provided
                                     continue
 
-                                if (context_value is None) and (actual_value is not None):
+                                if (context_value is None) and (
+                                    actual_value is not None
+                                ):
                                     # Any value matches, as long as it's set
                                     continue
 
                                 if (
-                                    isinstance(context_value, collections.abc.Collection)
+                                    isinstance(
+                                        context_value, collections.abc.Collection
+                                    )
                                     and not isinstance(context_value, str)
                                     and (actual_value in context_value)
                                 ):
@@ -341,9 +355,11 @@ def recognize_all(
                                 # Did not match required context
                                 filter_matches = False
                                 break
-                        
+
                         if filter_matches:
-                            maybe_match_context.matched_intent_filters.append(intent_filter)
+                            maybe_match_context.matched_intent_filters.append(
+                                intent_filter
+                            )
                             skip_match = False
 
                     if skip_match:
@@ -351,7 +367,9 @@ def recognize_all(
                         continue
 
                     # Add fixed entities
-                    for maybe_matched_filter in maybe_match_context.matched_intent_filters:
+                    for (
+                        maybe_matched_filter
+                    ) in maybe_match_context.matched_intent_filters:
                         for slot_name, slot_value in maybe_matched_filter.slots.items():
                             maybe_match_context.entities.append(
                                 MatchEntity(name=slot_name, value=slot_value, text="")

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -291,7 +291,6 @@ def recognize_all(
                     skip_match = True
 
                     for intent_filter in intent_data.filters:
-
                         filter_matches = True
 
                         # Verify excluded context

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -45,6 +45,19 @@ intents:
           domain: "cover"
         slots:
           domain: "cover"
+  OpenDoors:
+    data:
+      - sentences:
+          - "how many doors are open"
+        filters:
+          - slots:
+              domain: "cover"
+              device_class: "door"
+              state: "open"
+          - slots:
+              domain: "binary_sensor"
+              device_class: "door"
+              state: "on"
   Play:
     data:
       - sentences:
@@ -202,6 +215,20 @@ def test_close_not_light(intents, slot_lists):
     result = recognize("close the hue", intents, slot_lists=slot_lists)
     assert result is None
 
+
+# pylint: disable=redefined-outer-name
+def test_open_door(intents, slot_lists):
+    result = recognize("how many doors are open", intents, slot_lists=slot_lists)
+
+    assert result is not None
+    assert result.intent.name == "OpenDoors"
+
+    assert result.entities["device_class"].value == "door"
+
+    matched_domains = [entity.value for entity in result.entities_list if entity.name == "domain"]
+    assert "cover" in matched_domains
+    assert "binary_sensor" in matched_domains
+    
 
 # pylint: disable=redefined-outer-name
 def test_play(intents, slot_lists):

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -225,10 +225,12 @@ def test_open_door(intents, slot_lists):
 
     assert result.entities["device_class"].value == "door"
 
-    matched_domains = [entity.value for entity in result.entities_list if entity.name == "domain"]
+    matched_domains = [
+        entity.value for entity in result.entities_list if entity.name == "domain"
+    ]
     assert "cover" in matched_domains
     assert "binary_sensor" in matched_domains
-    
+
 
 # pylint: disable=redefined-outer-name
 def test_play(intents, slot_lists):

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -138,7 +138,7 @@ def test_turn_on(intents, slot_lists):
 
     assert "area" in result.entities
     assert len(result.entities["area"]) > 0
-    
+
     assert "area.kitchen" in result.entities["area"]
 
     # From YAML
@@ -236,6 +236,7 @@ def test_open_door(intents, slot_lists):
             assert matched_filters.entities["state"].value == "open"
         elif matched_filters.entities["domain"].value == "binary_sensor":
             assert matched_filters.entities["state"].value == "on"
+
 
 # pylint: disable=redefined-outer-name
 def test_play(intents, slot_lists):
@@ -442,7 +443,9 @@ def test_number_text() -> None:
         result = recognize(sentence, intents)
         assert result is not None, sentence
         assert result.entities_per_filter[0].entities["percentage"].value == 50
-        assert result.entities_per_filter[0].entities["percentage"].text.strip() == "50%"
+        assert (
+            result.entities_per_filter[0].entities["percentage"].text.strip() == "50%"
+        )
 
 
 def test_recognize_all() -> None:


### PR DESCRIPTION
According to [this discussion](https://discord.com/channels/330944238910963714/1106482051437297704), we should allow multiple "filters" for each `IntentData`, in order to be able to properly recognize sentences like
- "how many windows are open in the living room?", where one window is a `cover`, the other is a `binary_sensor`
- "how many locks are unlocked?" where one lock is a `lock`, the other is a `binary_sensor`
- etc

This is needed in the `intents` repo and then probably in the `core` repo