### PR TITLE
Local slot lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Uses a custom parser written in Python.
 * Slot Lists
   * `{list_name}`
   * `{list_name:slot_name}`
-  * Refers to a pre-defined list of values in YAML (`lists`)
+  * Refers to a pre-defined list of values in YAML (`lists`), either global or local (particular to the intent to which the sentence refers)
 * Expansion Rules
   * `<rule_name>`
   * Refers to a pre-defined expansion rule in YAML (`expansion_rules`), either global or local (particular to the intent to which the sentence refers)
@@ -104,6 +104,13 @@ intents:
         expansion_rules:
           # Expansion rules which only apply to the intent, referenced as <rule_name>
           <rule_name>: <sentence template>
+        lists:
+          # Lists which apply only to the current set of sentences, referenced as {list_name} or {list_name:slot_name}
+          <list name>:
+            values:
+              # See below for other possible types
+              - "items"
+              - "in list"
 
 # Optional lists of items that become alternatives in sentence templates
 lists:

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -429,7 +429,10 @@ def recognize_all(
                     continue
 
             local_settings = MatchSettings(
-                slot_lists=settings.slot_lists,
+                slot_lists={
+                    **settings.slot_lists,
+                    **intent_data.slot_lists,
+                },
                 expansion_rules={
                     **settings.expansion_rules,
                     **intent_data.expansion_rules,


### PR DESCRIPTION
Some slot lists are used very occasionally (i.e. in very few sentences), e.g. wildcard slots for items to add on TODO lists.

In this case, it's really not important to define them at the `_common.yaml` level, but rather at local sentence level.

This PR addresses this by allowing the creation of local slot lists.