### PR TITLE
Add support for text slot metadata

### DIFF
--- a/hassil/intents.py
+++ b/hassil/intents.py
@@ -69,21 +69,38 @@ class TextSlotValue:
     context: Optional[Dict[str, Any]] = None
     """Items added to context if value is matched"""
 
+    metadata: Optional[Dict[str, Any]] = None
+    """Additional metadata to be returned if value is matched"""
+
     @staticmethod
     def from_tuple(
-        value_tuple: Union[Tuple[str, Any], Tuple[str, Any, Dict[str, Any]]],
+        value_tuple: Union[
+            Tuple[str, Any],
+            Tuple[str, Any, Dict[str, Any]],
+            Tuple[str, Any, Dict[str, Any], Dict[str, Any]],
+        ],
         allow_template: bool = True,
     ) -> "TextSlotValue":
         """Construct text slot value from a tuple."""
-        text_in, value_out, context = value_tuple[0], value_tuple[1], None
+        text_in, value_out, context, metadata = (
+            value_tuple[0],
+            value_tuple[1],
+            None,
+            None,
+        )
 
         if len(value_tuple) > 2:
             context = cast(Tuple[str, Any, Dict[str, Any]], value_tuple)[2]
+        if len(value_tuple) > 3:
+            metadata = cast(
+                Tuple[str, Any, Dict[str, Any], Dict[str, Any]], value_tuple
+            )[3]
 
         return TextSlotValue(
             text_in=_maybe_parse_template(text_in, allow_template),
             value_out=value_out,
             context=context,
+            metadata=metadata,
         )
 
 
@@ -114,7 +131,13 @@ class TextSlotList(SlotList):
 
     @staticmethod
     def from_tuples(
-        tuples: Iterable[Union[Tuple[str, Any], Tuple[str, Any, Dict[str, Any]]]],
+        tuples: Iterable[
+            Union[
+                Tuple[str, Any],
+                Tuple[str, Any, Dict[str, Any]],
+                Tuple[str, Any, Dict[str, Any], Dict[str, Any]],
+            ]
+        ],
         allow_template: bool = True,
     ) -> "TextSlotList":
         """
@@ -349,6 +372,7 @@ def _parse_list(
                         text_in=_maybe_parse_template(value["in"], allow_template),
                         value_out=value["out"],
                         context=value.get("context"),
+                        metadata=value.get("metadata"),
                     )
                 )
 

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -71,6 +71,9 @@ class MatchEntity:
     text: str
     """Original value text."""
 
+    metadata: Optional[Dict[str, Any]] = None
+    """Entity metadata."""
+
     is_wildcard: bool = False
     """True if entity is a wildcard."""
 
@@ -1023,6 +1026,7 @@ def match_expression(
                                 text=context.text[: -len(value_context.text)]
                                 if value_context.text
                                 else context.text,
+                                metadata=slot_value.metadata,
                             )
                         ]
 

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1098,3 +1098,33 @@ def test_wildcard_punctuation() -> None:
     assert set(result.entities.keys()) == {"name", "zone"}
     assert result.entities["name"].value == "alice "
     assert result.entities["zone"].value == "new york"
+
+
+def test_entity_metadata() -> None:
+    """Ensure metadata is returned for text slots"""
+    yaml_text = """
+    language: "en"
+    intents:
+      TestIntent:
+        data:
+          - sentences:
+              - "run test {name} [now]"
+              - "{name} test"
+    lists:
+      name:
+        values:
+          - in: "alpha "
+            out: "A"
+            metadata:
+              is_alpha: true
+    """
+
+    with io.StringIO(yaml_text) as test_file:
+        intents = Intents.from_yaml(test_file)
+
+    for sentence in ("run test alpha, now", "run test alpha!", "alpha test"):
+        result = recognize(sentence, intents)
+        assert result is not None, sentence
+        assert result.entities["name"].value == "A"
+        assert result.entities["name"].text_clean == "alpha"
+        assert result.entities["name"].metadata == {"is_alpha": True}


### PR DESCRIPTION
This is part of a larger Home Assistant PR, but essentially it allows passing additional data through on text slots which can be accessed on the returned entities.