### PR TITLE
String representation of MatchEntity

### DIFF
--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -85,6 +85,10 @@ class MatchEntity:
         """Trimmed text with punctuation removed."""
         return PUNCTUATION.sub("", self.text.strip())
 
+    def __str__(self) -> str:
+        """String representation of a match entity."""
+        return self.text or self.value
+
 
 @dataclass
 class UnmatchedEntity(ABC):


### PR DESCRIPTION
Allow `MatchEntity` objects to be passed directly to response templates, so that we can have both what the user said and what the value is.

To keep backwards compatibility with the existing templates (especially in custom sentences), if we pass the objects instead of one of their properties, a string representation of these objects must exist.