### PR TITLE
Initialize wildcard_text if wildcard is not None

### DIFF
--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -982,7 +982,7 @@ def match_expression(
                     # the current chunk text.
                     skip_idx = context_text.find(chunk_text)
                     if skip_idx >= 0:
-                        wildcard_text += context_text[:skip_idx]
+                        wildcard_text = context_text[:skip_idx]
 
                         # Wildcards cannot be empty
                         if wildcard_text:


### PR DESCRIPTION
Hey, thanks a lot for your work!
If I'm not mistaken, the variable `wildcard_text` has not been initialized correctly in the `wildcard is not None` branch of the `match_expression`, thus the `+=` does not work here