### PR TITLE
Allow number ranges to have the same start/stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1
+
+- Allow number ranges to have the same start/stop (single number)
+
 ## 2.1.0
 
 - Upgrade to `unicode-rbnf` 2.2

--- a/hassil/intents.py
+++ b/hassil/intents.py
@@ -45,7 +45,7 @@ class RangeSlotList(SlotList):
 
     def __post_init__(self):
         """Validate number range"""
-        assert self.start < self.stop, "start must be less than stop"
+        assert self.start <= self.stop, "start cannot be greater than stop"
         assert self.step > 0, "step must be positive"
         assert self.digits or self.words, "must have digits, words, or both"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "hassil"
-version     = "2.1.0"
+version     = "2.1.1"
 license     = {text = "Apache-2.0"}
 description = "The Home Assistant Intent Language parser"
 readme      = "README.md"

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1725,3 +1725,27 @@ def test_wildcard_then_other_stuff() -> None:
     assert result.entities["item"].value == "apples"
     assert result.entities["todo_list"].text == "shopping list"
     assert result.entities["todo_list"].value == "shopping list"
+
+
+def test_range_list_with_one_number() -> None:
+    """Test a range list with the same start/stop value."""
+    yaml_text = """
+    language: "en"
+    intents:
+      TestIntent:
+        data:
+          - sentences:
+              - "test {value}"
+    lists:
+      value:
+        range:
+          from: 1
+          to: 1
+    """
+
+    with io.StringIO(yaml_text) as test_file:
+        intents = Intents.from_yaml(test_file)
+
+    # Check ranges
+    assert recognize("test 1", intents)
+    assert not recognize("test 2", intents)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for Version 2.1.1

- **New Features**
  - Added support for number ranges with the same start and stop values
  - Now allows treating a single number as a valid range

- **Bug Fixes**
  - Modified range validation to accept ranges where start and stop values are equal

- **Tests**
  - Added test coverage for single-number range scenarios

This update improves the flexibility of number range handling in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->