### PR TITLE
Add fractions for ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.2.0
+
+- Add "fractions" to number ranges with halves and tenths
+- Don't remove punctuation within words in `text_clean` (e.g., "2.5")
+
 ## 2.1.1
 
 - Allow number ranges to have the same start/stop (single number)

--- a/hassil/models.py
+++ b/hassil/models.py
@@ -4,7 +4,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 
-from .util import PUNCTUATION_ALL
+from .util import remove_punctuation
 
 
 @dataclass
@@ -32,7 +32,7 @@ class MatchEntity:
     @property
     def text_clean(self) -> str:
         """Trimmed text with punctuation removed."""
-        return PUNCTUATION_ALL.sub("", self.text.strip())
+        return remove_punctuation(self.text).strip()
 
 
 @dataclass

--- a/hassil/sample.py
+++ b/hassil/sample.py
@@ -185,9 +185,7 @@ def sample_expression(
                 return
 
             if range_list.digits:
-                number_strs = map(
-                    str, range(range_list.start, range_list.stop + 1, range_list.step)
-                )
+                number_strs = map(str, range_list.get_numbers())
                 yield from number_strs
 
             if range_list.words:
@@ -201,9 +199,7 @@ def sample_expression(
                     assert engine is not None
 
                     # digits -> words
-                    for word_number in range(
-                        range_list.start, range_list.stop + 1, range_list.step
-                    ):
+                    for word_number in range_list.get_numbers():
                         # Use all unique words for a number, including different
                         # genders, cases, etc.
                         format_result = engine.format_number(word_number)

--- a/hassil/string_matcher.py
+++ b/hassil/string_matcher.py
@@ -34,12 +34,12 @@ from .models import (
 )
 from .trie import Trie
 from .util import (
-    PUNCTUATION_ALL,
     WHITESPACE,
     check_excluded_context,
     check_required_context,
     match_first,
     match_start,
+    remove_punctuation,
 )
 
 NUMBER_START = re.compile(r"^(\s*-?[0-9]+(?:\.[0-9]+)?)")
@@ -124,7 +124,7 @@ class MatchContext:
     @property
     def is_match(self) -> bool:
         """True if no text is left that isn't just whitespace or punctuation"""
-        text = PUNCTUATION_ALL.sub("", self.text).strip()
+        text = remove_punctuation(self.text).strip()
         if text:
             return False
 

--- a/hassil/util.py
+++ b/hassil/util.py
@@ -13,7 +13,6 @@ TEMPLATE_SYNTAX = re.compile(r".*[(){}<>\[\]|].*")
 
 PUNCTUATION_STR = ".。,，?¿？؟!¡！;；:：’"
 PUNCTUATION_PATTERN = rf"[{re.escape(PUNCTUATION_STR)}]+"
-PUNCTUATION_ALL = re.compile(rf"{PUNCTUATION_PATTERN}")
 PUNCTUATION_START = re.compile(rf"^{PUNCTUATION_PATTERN}")
 PUNCTUATION_END = re.compile(rf"{PUNCTUATION_PATTERN}$")
 PUNCTUATION_END_SPACE = re.compile(rf"{PUNCTUATION_PATTERN}\s*$")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "hassil"
-version     = "2.1.1"
+version     = "2.2.0"
 license     = {text = "Apache-2.0"}
 description = "The Home Assistant Intent Language parser"
 readme      = "README.md"

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1858,3 +1858,79 @@ def test_range_list_with_tenths() -> None:
 
     # Only tenths
     assert not recognize("test 2.12", intents)
+
+
+def test_range_lists_separated_by_punctuation() -> None:
+    """Test range lists separated by punctuation."""
+    yaml_text = """
+    language: "en"
+    intents:
+      TestIntent:
+        data:
+          - sentences:
+              - "test {value1}.{value2}"
+    lists:
+      value1:
+        range:
+          from: 0
+          to: 1
+      value2:
+        range:
+          from: 0
+          to: 2
+    """
+
+    with io.StringIO(yaml_text) as test_file:
+        intents = Intents.from_yaml(test_file)
+
+    result = recognize("test 1.2", intents)
+    assert result is not None
+
+    value1 = result.entities.get("value1")
+    assert value1 is not None
+    assert value1.value == 1
+
+    value2 = result.entities.get("value2")
+    assert value2 is not None
+    assert value2.value == 2
+
+
+def test_range_lists_separated_by_punctuation_with_wildcard() -> None:
+    """Test range lists separated by punctuation preceeded by a wildcard."""
+    yaml_text = """
+    language: "en"
+    intents:
+      TestIntent:
+        data:
+          - sentences:
+              - "test {anything} {value1}.{value2}"
+    lists:
+      anything:
+        wildcard: true
+      value1:
+        range:
+          from: 0
+          to: 1
+      value2:
+        range:
+          from: 0
+          to: 2
+    """
+
+    with io.StringIO(yaml_text) as test_file:
+        intents = Intents.from_yaml(test_file)
+
+    result = recognize("test for the big 1.2", intents)
+    assert result is not None
+
+    anything = result.entities.get("anything")
+    assert anything is not None
+    assert anything.value == "for the big"
+
+    value1 = result.entities.get("value1")
+    assert value1 is not None
+    assert value1.value == 1
+
+    value2 = result.entities.get("value2")
+    assert value2 is not None
+    assert value2.value == 2

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1047,7 +1047,7 @@ def test_wildcard() -> None:
     assert result is None, f"{sentence} should not match"
 
     # Test without text at the end
-    sentence = "start the white album by the beatles"
+    sentence = "start the white album by the beatles."
     result = recognize(sentence, intents)
     assert result is not None, f"{sentence} should match"
     assert set(result.entities.keys()) == {"album", "artist"}
@@ -1772,10 +1772,37 @@ def test_range_list_with_halves() -> None:
         intents = Intents.from_yaml(test_file)
 
     assert recognize("test 1", intents)
-    assert recognize("test 1.5", intents)
-    assert recognize("test one point five", intents, language="en")
-    assert recognize("test 2.0", intents)
-    assert recognize("test 2.5", intents)
+    result = recognize("test 1.5", intents)
+    assert result is not None
+    value = result.entities.get("value")
+    assert value is not None
+    assert value.value == 1.5
+    assert value.text == "1.5"
+    assert value.text_clean == "1.5"
+
+    result = recognize("test one point five", intents, language="en")
+    assert result is not None
+    value = result.entities.get("value")
+    assert value is not None
+    assert value.value == 1.5
+    assert value.text == "one point five"
+    assert value.text_clean == "one point five"
+
+    result = recognize("test 2.0", intents)
+    assert result is not None
+    value = result.entities.get("value")
+    assert value is not None
+    assert value.value == 2
+    assert value.text == "2.0"
+    assert value.text_clean == "2.0"
+
+    result = recognize("test 2.5", intents)
+    assert result is not None
+    value = result.entities.get("value")
+    assert value is not None
+    assert value.value == 2.5
+    assert value.text == "2.5"
+    assert value.text_clean == "2.5"
 
     # Only halves
     assert not recognize("test 2.1", intents)
@@ -1806,10 +1833,28 @@ def test_range_list_with_tenths() -> None:
 
     for integer in range(1, 3):
         for tenth in range(1, 10):
-            assert recognize(f"test {integer}.{tenth}", intents)
+            value_str = f"{integer}.{tenth}"
+            result = recognize(f"test {value_str}", intents)
+            assert result is not None
+            value = result.entities.get("value")
+            assert value is not None
+            assert value.value == float(value_str)
+            assert value.text == value_str
+            assert value.text_clean == value_str
 
-    assert recognize("test one point one", intents, language="en")
-    assert recognize("test two point six", intents, language="en")
+    result = recognize("test one point one", intents, language="en")
+    assert result is not None
+    value = result.entities.get("value")
+    assert value is not None
+    assert value.value == 1.1
+    assert value.text == "one point one"
+
+    result = recognize("test two point six", intents, language="en")
+    assert result is not None
+    value = result.entities.get("value")
+    assert value is not None
+    assert value.value == 2.6
+    assert value.text == "two point six"
 
     # Only tenths
     assert not recognize("test 2.12", intents)

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1749,3 +1749,67 @@ def test_range_list_with_one_number() -> None:
     # Check ranges
     assert recognize("test 1", intents)
     assert not recognize("test 2", intents)
+
+
+def test_range_list_with_halves() -> None:
+    """Test a range list with fractions (1/2)."""
+    yaml_text = """
+    language: "en"
+    intents:
+      TestIntent:
+        data:
+          - sentences:
+              - "test {value}"
+    lists:
+      value:
+        range:
+          from: 1
+          to: 2
+          fractions: halves
+    """
+
+    with io.StringIO(yaml_text) as test_file:
+        intents = Intents.from_yaml(test_file)
+
+    assert recognize("test 1", intents)
+    assert recognize("test 1.5", intents)
+    assert recognize("test one point five", intents, language="en")
+    assert recognize("test 2.0", intents)
+    assert recognize("test 2.5", intents)
+
+    # Only halves
+    assert not recognize("test 2.1", intents)
+
+
+def test_range_list_with_tenths() -> None:
+    """Test a range list with fractions (1/10)."""
+    yaml_text = """
+    language: "en"
+    intents:
+      TestIntent:
+        data:
+          - sentences:
+              - "test {value}"
+    lists:
+      value:
+        range:
+          from: 1
+          to: 2
+          fractions: tenths
+    """
+
+    with io.StringIO(yaml_text) as test_file:
+        intents = Intents.from_yaml(test_file)
+
+    assert recognize("test 1", intents)
+    assert recognize("test 2", intents)
+
+    for integer in range(1, 3):
+        for tenth in range(1, 10):
+            assert recognize(f"test {integer}.{tenth}", intents)
+
+    assert recognize("test one point one", intents, language="en")
+    assert recognize("test two point six", intents, language="en")
+
+    # Only tenths
+    assert not recognize("test 2.12", intents)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,5 +1,5 @@
 from hassil import parse_sentence
-from hassil.intents import RangeSlotList, TextSlotList
+from hassil.intents import RangeFractionType, RangeSlotList, TextSlotList
 from hassil.sample import sample_expression
 
 
@@ -87,6 +87,52 @@ def test_list_range_words():
         "run test two",
         "run test 3",
         "run test three",
+    }
+
+
+def test_list_range_halves_words():
+    sentence = parse_sentence("run test {num}")
+    num_list = RangeSlotList(
+        name=None, start=1, stop=1, fraction_type=RangeFractionType.HALVES, words=True
+    )
+    assert set(
+        sample_expression(sentence, slot_lists={"num": num_list}, language="en")
+    ) == {
+        "run test 1",
+        "run test one",
+        "run test 1.5",
+        "run test one point five",
+    }
+
+
+def test_list_range_tenths_words():
+    sentence = parse_sentence("run test {num}")
+    num_list = RangeSlotList(
+        name=None, start=1, stop=1, fraction_type=RangeFractionType.TENTHS, words=True
+    )
+    assert set(
+        sample_expression(sentence, slot_lists={"num": num_list}, language="en")
+    ) == {
+        "run test 1",
+        "run test one",
+        "run test 1.1",
+        "run test one point one",
+        "run test 1.2",
+        "run test one point two",
+        "run test 1.3",
+        "run test one point three",
+        "run test 1.4",
+        "run test one point four",
+        "run test 1.5",
+        "run test one point five",
+        "run test 1.6",
+        "run test one point six",
+        "run test 1.7",
+        "run test one point seven",
+        "run test 1.8",
+        "run test one point eight",
+        "run test 1.9",
+        "run test one point nine",
     }
 
 


### PR DESCRIPTION
Extends range lists with fractions, either halves or tenths:

```yaml
lists:
  range_with_halves:
    from: 1
    to: 2
    fractions: halves

  range_with_tenths:
    from: 1
    to: 2
    fractions: tenths
```

The `range_with_halves` list will accept 1, 1.5, 2, and 2.5 as well as their spoken equivalents according to [unicode-rbnf](https://github.com/rhasspy/unicode-rbnf) (e.g., "one point five").

The `range_with_tenths` list will accept 1, 1.1, ..., 2, 2.1, ..., 2.9 as well as the spoken equivalents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for fractional ranges (halves and tenths) in number recognition and parsing.
	- Enhanced numeric handling to include decimal and fractional values.
	- Expanded range slot list functionality to generate numbers with fractional representations.
	- Updated text cleaning process to preserve punctuation within numeric values.

- **Tests**
	- Added test cases for range lists with halves and tenths.
	- Improved test coverage for fractional number parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->