### PR TITLE
Update RegEx wildcard matching to avoid matching the next word inside of a wildcard

### DIFF
--- a/hassil/util.py
+++ b/hassil/util.py
@@ -208,8 +208,8 @@ def match_first(text: str, prefix: str, start_idx: int = 0) -> int:
     if start_idx > 0:
         text = text[start_idx:]
 
-    # Use word boundary anchors to ensure the prefix matches as a whole word
-    match = re.search(rf"\b{re.escape(prefix)}\b", text, re.IGNORECASE)
+    # Use word boundary anchor to ensure the prefix only matches the start of a word
+    match = re.search(rf"\b{re.escape(prefix)}", text, re.IGNORECASE)
     if match is None:
         return -1
 

--- a/hassil/util.py
+++ b/hassil/util.py
@@ -208,7 +208,8 @@ def match_first(text: str, prefix: str, start_idx: int = 0) -> int:
     if start_idx > 0:
         text = text[start_idx:]
 
-    match = re.search(rf"{re.escape(prefix)}", text, re.IGNORECASE)
+    # Use word boundary anchors to ensure the prefix matches as a whole word
+    match = re.search(rf"\b{re.escape(prefix)}\b", text, re.IGNORECASE)
     if match is None:
         return -1
 

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1076,6 +1076,16 @@ def test_wildcard() -> None:
         assert result.entities["album"].is_wildcard
         assert result.entities["artist"].is_wildcard
 
+    # Test use of next word at end of word in wildcard
+    sentence = "play Moby by Moby please now"
+    result = recognize(sentence, intents)
+    assert result is not None, f"{sentence} should match"
+    assert set(result.entities.keys()) == {"album", "artist"}
+    assert result.entities["album"].value == "Moby"
+    assert result.entities["album"].is_wildcard
+    assert result.entities["artist"].value == "Moby"
+    assert result.entities["artist"].is_wildcard
+
     # Add "artist" word
     sentence = "begin day by day by artist taken by trees"
     result = recognize(sentence, intents)


### PR DESCRIPTION
This should fix the bug where wildcards are incorrectly split up if one of their words ends with the next expected word in the sentence.

Fixes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced prefix matching precision in word recognition
	- Added test case for wildcard entity recognition with identical album and artist names

- **Tests**
	- Expanded test coverage for wildcard matching scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->