### PR TITLE
Allow list values with "in" but no "out"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.1
+
+- Allow list values with "in" but no "out"
+
 ## 2.2.0
 
 - Add "fractions" to number ranges with halves and tenths

--- a/hassil/intents.py
+++ b/hassil/intents.py
@@ -419,11 +419,15 @@ def _parse_list(
         # Text values
         text_values: List[TextSlotValue] = []
         for value in list_dict["values"]:
+            if isinstance(value, str) and allow_template and is_template(value):
+                # Wrap template
+                value = {"in": value}
+
             if isinstance(value, str):
                 # String value
                 text_values.append(
                     TextSlotValue(
-                        text_in=_maybe_parse_template(value, allow_template),
+                        text_in=_maybe_parse_template(value, allow_template=False),
                         value_out=value,
                     )
                 )
@@ -432,7 +436,7 @@ def _parse_list(
                 text_values.append(
                     TextSlotValue(
                         text_in=_maybe_parse_template(value["in"], allow_template),
-                        value_out=value["out"],
+                        value_out=value.get("out"),
                         context=value.get("context"),
                         metadata=value.get("metadata"),
                     )

--- a/hassil/string_matcher.py
+++ b/hassil/string_matcher.py
@@ -512,15 +512,21 @@ def match_expression(
                         else:
                             remaining_text = context.text
 
+                        entity_text = (
+                            remaining_text[: -len(value_context.text)]
+                            if value_context.text
+                            else remaining_text
+                        )
+
                         entities = value_context.entities + [
                             MatchEntity(
                                 name=list_ref.slot_name,
-                                value=slot_value.value_out,
-                                text=(
-                                    remaining_text[: -len(value_context.text)]
-                                    if value_context.text
-                                    else remaining_text
+                                value=(
+                                    entity_text
+                                    if slot_value.value_out is None
+                                    else slot_value.value_out
                                 ),
+                                text=entity_text,
                                 metadata=slot_value.metadata,
                             )
                         ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "hassil"
-version     = "2.2.0"
+version     = "2.2.1"
 license     = {text = "Apache-2.0"}
 description = "The Home Assistant Intent Language parser"
 readme      = "README.md"

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1934,3 +1934,42 @@ def test_range_lists_separated_by_punctuation_with_wildcard() -> None:
     value2 = result.entities.get("value2")
     assert value2 is not None
     assert value2.value == 2
+
+
+def test_list_value_in_no_out() -> None:
+    """Test list values with "in" but no "out"."""
+    yaml_text = """
+    language: "en"
+    intents:
+      TestIntent:
+        data:
+          - sentences:
+              - "test {value1}"
+          - sentences:
+              - "also test {value2}"
+            lists:
+              value2:
+                values:
+                  - g[h]i
+                  - j[k]l
+    lists:
+      value1:
+        values:
+          - a[b]c
+          - in: d[e]f
+    """
+
+    with io.StringIO(yaml_text) as test_file:
+        intents = Intents.from_yaml(test_file)
+
+    for value in ("abc", "ac", "def", "df"):
+        result = recognize(f"test {value}", intents)
+        assert result is not None, value
+        assert "value1" in result.entities
+        assert result.entities["value1"].value == value
+
+    for value in ("ghi", "gi", "jkl", "jl"):
+        result = recognize(f"also test {value}", intents)
+        assert result is not None, value
+        assert "value2" in result.entities
+        assert result.entities["value2"].value == value


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Version 2.2.1

- **New Features**
  - Added support for list values with "in" specification but no "out" value

- **Bug Fixes**
  - Improved handling of list value recognition in template parsing

- **Tests**
  - Added new test case to validate list value recognition with partial specifications

- **Chores**
  - Updated project version number to 2.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->