### PR TITLE
Add "," as decimal separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.2
+
+- Allow "," as a decimal separator for fractional ranges
+
 ## 2.2.1
 
 - Allow list values with "in" but no "out"

--- a/hassil/string_matcher.py
+++ b/hassil/string_matcher.py
@@ -43,9 +43,9 @@ from .util import (
 )
 
 INTEGER_START = re.compile(r"^(\s*-?[0-9]+)")
-FLOAT_START = re.compile(r"^(\s*-?[0-9]+(?:\.[0-9]+)?)")
+FLOAT_START = re.compile(r"^(\s*-?[0-9]+(?:[.,][0-9]+)?)")
 INTEGER_ANYWHERE = re.compile(r"(\s*-?[0-9])")
-FLOAT_ANYWHERE = re.compile(r"(\s*-?[0-9]+(?:\.[0-9]+)?)")
+FLOAT_ANYWHERE = re.compile(r"(\s*-?[0-9]+(?:[.,][0-9]+)?)")
 BREAK_WORDS_TABLE = str.maketrans("-_", "  ")
 
 # lang -> engine
@@ -606,7 +606,9 @@ def match_expression(
                 if range_list.digits and number_matches:
                     for number_match in number_matches:
                         number_text = number_match[1]
-                        word_number: Union[int, float] = float(number_text)
+                        word_number: Union[int, float] = float(
+                            number_text.replace(",", ".")  # normalize decimal separator
+                        )
 
                         # Check if number is within range of our list
                         if (range_list.step == 1) and (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "hassil"
-version     = "2.2.1"
+version     = "2.2.2"
 license     = {text = "Apache-2.0"}
 description = "The Home Assistant Intent Language parser"
 readme      = "README.md"

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -1807,6 +1807,15 @@ def test_range_list_with_halves() -> None:
     # Only halves
     assert not recognize("test 2.1", intents)
 
+    # Comma separator
+    result = recognize("test 2,5", intents)
+    assert result is not None
+    value = result.entities.get("value")
+    assert value is not None
+    assert value.value == 2.5
+    assert value.text == "2,5"
+    assert value.text_clean == "2,5"
+
 
 def test_range_list_with_tenths() -> None:
     """Test a range list with fractions (1/10)."""


### PR DESCRIPTION
Allow both "." and "," as a decimal separator for fractional ranges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fractional range parsing now supports using commas as decimal separators.

- **Bug Fixes**
  - Removed unintended support for list values with "in" but no "out" to ensure consistent numeric interpretation.

- **Tests**
  - Added a test case to verify the correct conversion and recognition of comma-formatted decimal numbers.

- **Chores**
  - Updated the project version to 2.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->