### PR TITLE
Preserve initialism at end of sentence

### DIFF
--- a/hassil/util.py
+++ b/hassil/util.py
@@ -20,6 +20,8 @@ PUNCTUATION_START_WORD = re.compile(rf"(?<=\W){PUNCTUATION_PATTERN}(?=\w)")
 PUNCTUATION_END_WORD = re.compile(rf"(?<=\w){PUNCTUATION_PATTERN}(?=\W)")
 PUNCTUATION_WORD = re.compile(rf"(?<=\W){PUNCTUATION_PATTERN}(?=\W)")
 
+INITIALISM_DOTS_AT_END = re.compile(r"\b(?:\w\.){2,}$")
+
 
 def merge_dict(base_dict, new_dict):
     """Merges new_dict into base_dict."""
@@ -188,7 +190,11 @@ def remove_skip_words(
 
 def remove_punctuation(text: str) -> str:
     text = PUNCTUATION_START.sub("", text)
-    text = PUNCTUATION_END.sub("", text)
+
+    if not INITIALISM_DOTS_AT_END.match(text):
+        # Don't remove final "." from "A.C.", etc.
+        text = PUNCTUATION_END.sub("", text)
+
     text = PUNCTUATION_START_WORD.sub("", text)
     text = PUNCTUATION_END_WORD.sub("", text)
     text = PUNCTUATION_WORD.sub("", text)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,7 @@ from hassil.util import (
     normalize_text,
     normalize_whitespace,
     remove_escapes,
+    remove_punctuation,
 )
 
 
@@ -32,3 +33,10 @@ def test_is_template():
     assert is_template("a <rule>")
     assert is_template("(a group)")
     assert is_template("an | alternative")
+
+
+def test_remove_punctuation():
+    assert remove_punctuation("test") == "test"
+    assert remove_punctuation("test.") == "test"
+    assert remove_punctuation("A.C.") == "A.C."
+    assert remove_punctuation("A.C") == "A.C"


### PR DESCRIPTION
Avoid stripping final "." from things sentences like "turn on the A.C."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text punctuation handling to preserve final periods in abbreviations, ensuring that shorthand notations display correctly.
  
- **Tests**
  - Added new test cases to validate the updated punctuation behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->