### PR TITLE
Restore permutations improvement

### DIFF
--- a/hassil/expression.py
+++ b/hassil/expression.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from abc import ABC
 from dataclasses import dataclass, field
-from typing import Dict, Iterator, List, Optional
+from typing import Dict, Iterable, Iterator, List, Optional, Tuple
 
 
 @dataclass
@@ -101,6 +101,14 @@ class Alternative(Group):
 @dataclass
 class Permutation(Group):
     """Permutations of a set of expressions."""
+
+    def iterate_permutations(self) -> Iterable[Tuple[Expression, Permutation]]:
+        """Iterate over all permutations."""
+        for i, item in enumerate(self.items):
+            items = self.items.copy()
+            del items[i]
+            rest = Permutation(items=items)
+            yield (item, rest)
 
 
 @dataclass

--- a/hassil/string_matcher.py
+++ b/hassil/string_matcher.py
@@ -1,6 +1,5 @@
 """Original hassil matcher."""
 
-import itertools
 import logging
 import re
 from collections import defaultdict
@@ -453,21 +452,14 @@ def match_expression(
                 yield from group_contexts
 
         elif isinstance(grp, Permutation):
-            for permutation in itertools.permutations(grp.items, len(grp.items)):
-                perm_contexts = [context]
-                for item in permutation:
-                    # Next step
-                    perm_contexts = [
-                        item_context
-                        for perm_context in perm_contexts
-                        for item_context in match_expression(
-                            settings, perm_context, item
-                        )
-                    ]
-                    if not perm_contexts:
-                        break
+            if len(grp.items) == 1:
+                yield from match_expression(settings, context, grp.items[0])
+            else:
+                # All must match (in arbitrary order)
+                for item, rest in grp.iterate_permutations():
+                    for item_context in match_expression(settings, context, item):
+                        yield from match_expression(settings, item_context, rest)
 
-                yield from perm_contexts
         else:
             raise ValueError(f"Unexpected group type: {grp}")
 


### PR DESCRIPTION
Restore permutations improvement. The goal of this change was to improve the speed of permutations.

Example to test:

```py
from hassil import is_match, parse_sentence
sentence = parse_sentence("(a;b;c;d;e;f)")
import timeit
timeit.timeit("is_match('c a b d r i v e r', sentence)", number=1000, globals=globals())
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced improved handling of expression groupings, offering comprehensive iteration over different orderings.
- **Refactor**
	- Simplified the matching process to streamline logic and enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->