### PR TITLE
Resolve number formatting engines by script, not just language family

### DIFF
--- a/hassil/numbers.py
+++ b/hassil/numbers.py
@@ -1,0 +1,61 @@
+"""Number formatting engines for range lists."""
+
+from typing import Dict, Iterable
+
+from unicode_rbnf import RbnfEngine
+
+_ENGINE_CACHE: Dict[str, RbnfEngine] = {}
+
+# Languages whose script is implied by their region, following CLDR
+# likelySubtags. Without these, a region code falls back to the bare language
+# and picks up the wrong script: zh-TW would load Simplified rules and only
+# recognize 两 instead of 兩.
+#
+# Keys are lower-cased and use "_" as the separator.
+_SCRIPT_ALIASES = {
+    "zh_hk": "zh_Hant",
+    "zh_mo": "zh_Hant",
+    "zh_tw": "zh_Hant",
+}
+
+
+def _candidate_languages(language: str) -> Iterable[str]:
+    """Generate language codes to try, from most to least specific."""
+    yield language
+
+    # unicode-rbnf names its files with "_" (sr_Latn, de_CH)
+    normalized = language.replace("-", "_")
+    if normalized != language:
+        yield normalized
+
+    alias = _SCRIPT_ALIASES.get(normalized.lower())
+    if alias is not None:
+        yield alias
+
+    # Fall back to the language family, e.g. "en" for "en-US"
+    family = normalized.split("_", maxsplit=1)[0]
+    if family != normalized:
+        yield family
+
+
+def get_rbnf_engine(language: str) -> RbnfEngine:
+    """Get a number formatting engine for a language.
+
+    Raises ValueError if no engine is available.
+    """
+    engine = _ENGINE_CACHE.get(language)
+    if engine is not None:
+        return engine
+
+    last_error: ValueError = ValueError(f"{language} is not supported")
+    for candidate in _candidate_languages(language):
+        try:
+            engine = RbnfEngine.for_language(candidate)
+        except ValueError as err:
+            last_error = err
+            continue
+
+        _ENGINE_CACHE[language] = engine
+        return engine
+
+    raise last_error

--- a/hassil/sample.py
+++ b/hassil/sample.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Dict, Iterable, Optional, Set, Tuple
 
 import yaml
-from unicode_rbnf import RbnfEngine
 
 from .errors import MissingListError, MissingRuleError
 from .expression import (
@@ -25,12 +24,12 @@ from .expression import (
     TextChunk,
 )
 from .intents import Intents, RangeSlotList, SlotList, TextSlotList, WildcardSlotList
+from .numbers import get_rbnf_engine
 from .util import merge_dict, normalize_whitespace
 
 _LOGGER = logging.getLogger("hassil.sample")
 
 # lang -> engine
-_ENGINE_CACHE: Dict[str, RbnfEngine] = {}
 
 
 def sample_intents(
@@ -242,12 +241,7 @@ def sample_expression(
             if range_list.words:
                 words_language = range_list.words_language or language
                 if words_language:
-                    engine = _ENGINE_CACHE.get(words_language)
-                    if engine is None:
-                        engine = RbnfEngine.for_language(words_language)
-                        _ENGINE_CACHE[words_language] = engine
-
-                    assert engine is not None
+                    engine = get_rbnf_engine(words_language)
 
                     # digits -> words
                     for word_number in range_list.get_numbers():

--- a/hassil/string_matcher.py
+++ b/hassil/string_matcher.py
@@ -6,8 +6,6 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
-from unicode_rbnf import RbnfEngine
-
 from .errors import MissingListError, MissingRuleError
 from .expression import (
     Alternative,
@@ -35,6 +33,7 @@ from .models import (
     UnmatchedRangeEntity,
     UnmatchedTextEntity,
 )
+from .numbers import get_rbnf_engine
 from .trie import Trie
 from .util import (
     WHITESPACE,
@@ -50,9 +49,6 @@ FLOAT_START = re.compile(r"^(\s*-?[0-9]+(?:[.,][0-9]+)?)")
 INTEGER_ANYWHERE = re.compile(r"(\s*-?[0-9])")
 FLOAT_ANYWHERE = re.compile(r"(\s*-?[0-9]+(?:[.,][0-9]+)?)")
 BREAK_WORDS_TABLE = str.maketrans("-_", "  ")
-
-# lang -> engine
-_ENGINE_CACHE: Dict[str, RbnfEngine] = {}
 
 # lang -> number -> words
 _RANGE_TRIE_CACHE: Dict[
@@ -1004,21 +1000,7 @@ def _build_range_trie(language: str, range_list: RangeSlotList) -> Trie:
     range_trie = Trie()
 
     # Load number formatting engine
-    engine = _ENGINE_CACHE.get(language)
-    if engine is None:
-        try:
-            engine = RbnfEngine.for_language(language)
-        except ValueError as err:
-            # Fall back to language family (e.g., "en" for "en-US")
-            lang_match = re.match(r"^(.+)[-_].+$", language)
-            if lang_match:
-                lang_family = lang_match.group(1)
-                engine = RbnfEngine.for_language(lang_family)
-
-            if engine is None:
-                raise err
-
-        _ENGINE_CACHE[language] = engine
+    engine = get_rbnf_engine(language)
 
     for word_number in range_list.get_numbers():
         range_value: Union[float, int] = word_number

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -1,0 +1,58 @@
+"""Tests for number formatting engine lookup."""
+
+import pytest
+
+from hassil.numbers import get_rbnf_engine
+
+
+def _words(language: str, number: int) -> set:
+    """Return every spelled-out form of a number in a language."""
+    return set(get_rbnf_engine(language).format_number(number).text_by_ruleset.values())
+
+
+def test_exact_language() -> None:
+    """Test a language that unicode-rbnf supports directly."""
+    assert "two" in _words("en", 2)
+
+
+def test_language_family_fallback() -> None:
+    """Test that a region falls back to the language family."""
+    assert _words("en-US", 2) == _words("en", 2)
+
+
+def test_separator_is_normalized() -> None:
+    """Test that "-" is accepted where unicode-rbnf uses "_"."""
+    # Serbian written in Latin script, not the Cyrillic of the "sr" family.
+    assert "dva" in _words("sr-Latn", 2)
+    assert "два" not in _words("sr-Latn", 2)
+
+
+@pytest.mark.parametrize("language", ["zh-TW", "zh-HK", "zh-MO"])
+def test_traditional_chinese_regions(language: str) -> None:
+    """Test that regions using Traditional Chinese do not get Simplified rules."""
+    words = _words(language, 2)
+
+    # 兩 is how the quantity 2 is spoken; the Simplified 两 must not be used.
+    assert "兩" in words
+    assert "两" not in words
+
+    # 二 is written the same in both scripts and stays available.
+    assert "二" in words
+
+
+def test_simplified_chinese_is_unchanged() -> None:
+    """Test that Simplified regions still get the Simplified rules."""
+    words = _words("zh-CN", 2)
+    assert "两" in words
+    assert "兩" not in words
+
+
+def test_unsupported_language() -> None:
+    """Test that an unsupported language still raises."""
+    with pytest.raises(ValueError):
+        get_rbnf_engine("nonexistent-language")
+
+
+def test_engine_is_cached() -> None:
+    """Test that repeated lookups return the same engine."""
+    assert get_rbnf_engine("zh-TW") is get_rbnf_engine("zh-TW")


### PR DESCRIPTION
Fixes #277.

`zh-TW` and `zh-HK` build their range tries from Simplified Chinese rules, so a speaker saying 兩小時 (the only natural way to say "2 hours") gets no match, while the Simplified 两小時 does match.

`unicode-rbnf` already ships the right data — `zh_Hant.xml` — it was just never reached. Files there are named with `_`, and there is no alias from a region to the script that region implies, so `zh-TW` fell through to the bare `zh` family.

## Change

Engine lookup now tries, in order:

| step | example |
| --- | --- |
| the code as given | `en` → `en.xml` |
| separator normalized | `sr-Latn` → `sr_Latn.xml`, `de-CH` → `de_CH.xml` |
| script implied by region | `zh-TW` → `zh_Hant.xml` |
| language family (unchanged) | `en-US` → `en.xml` |

Only Chinese needs the third step; `sr-Latn` and `de-CH` are fixed by normalizing the separator alone. The alias map is three entries taken from CLDR likelySubtags (`zh_HK`, `zh_MO`, `zh_TW`).

The lookup and its engine cache were duplicated in `string_matcher` and `sample`, and the copy in `sample` had no fallback at all — `zh-TW` raised `ValueError` there rather than silently using the wrong script. Both now call `hassil.numbers.get_rbnf_engine`.

## What changes for Chinese

Three spoken forms differ between the scripts:

- `2` → 兩 not 两 — the quantity, as in 兩小時. The common case.
- `.5` → 點 not 点 — any half. The shared `climate.yaml` temperature range declares `fractions: halves`, so 二十二點五度.
- `>=10000` → 萬 not 万 — not reachable from current range lists, but `color_temperature` already goes to 10000.

The rest is `spellout-cardinal-financial` (贰/叁/陆), the formal forms used on cheques, which nobody says out loud.

`zh_Hant` has no `spellout-numbering-days` ruleset, so Traditional regions no longer map 初一/初二/初三 onto 1/2/3 in range slots. Those are lunar calendar day names, and nothing in the intents data consumes them — there is no lunar intent, and `HassGetCurrentDate` takes no slots. Their only effect was to let a lunar day name be read as a quantity.

## Verification

`tests/test_numbers.py` covers exact/family/separator/script resolution, both Chinese scripts, and the unsupported case.

```
pytest              152 passed (143 before + 9 new)
black/isort/flake8  clean
mypy                no issues in 18 source files
pylint              10.00/10
```

Trie contents, built directly:

```
zh-TW    ['兩', '二']     fixed
zh-CN    ['两', '二']     unchanged
sr-Latn  ['dva']         fixed
sr       ['два']         unchanged
```

Against [OHF-Voice/intents](https://github.com/OHF-Voice/intents) at `2f08327`, all 66 languages: **14,662 tests passed before and after**, and per-language sentence counts are identical. End to end:

```
設定一個兩小時的計時器      HassStartTimer {hours: 2}                 was NO MATCH
把溫控器設成二十二點五度    HassClimateSetTemperature {temp: 22.5}    was NO MATCH
設定一個2小時的計時器       unchanged
zh-CN 设置一个两小时的计时器  unchanged
```

## Caveat

I could not verify the `sr-Latn` improvement against real sentences — that language's test data contains no spelled-out numbers, so the passing suite only shows that nothing depended on the old behaviour. The trie check above is the only direct evidence. Confirmation from a Serbian speaker would be welcome.
