### PR TITLE
Strip whitespace only between CJK characters for ignore_whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.10.1
+
+- Only strip whitespace between CJK characters when `ignore_whitespace` is set, preserving spaces in non-CJK wildcard captures such as `Taylor Swift` ([#276](https://github.com/OHF-Voice/hassil/issues/276))
+
 ## 3.10.0
 
 - Add `filter_intents` to scope an `Intents` object to available domains/supported intents

--- a/hassil/recognize.py
+++ b/hassil/recognize.py
@@ -11,7 +11,7 @@ from .intents import Intent, IntentData, Intents, SlotList, WildcardSlotList
 from .models import MatchCapture, MatchEntity, UnmatchedEntity, UnmatchedTextEntity
 from .string_matcher import MatchContext, MatchSettings, match_expression
 from .util import (
-    WHITESPACE,
+    CJK_WHITESPACE,
     check_excluded_context,
     check_required_context,
     normalize_text,
@@ -260,8 +260,8 @@ def recognize_all(
 
     # Fall back to string matcher
     if intents.settings.ignore_whitespace:
-        text_no_skip_words = WHITESPACE.sub("", text_no_skip_words)
-        text_with_skip_words_matchable = WHITESPACE.sub("", text_with_skip_words)
+        text_no_skip_words = CJK_WHITESPACE.sub("", text_no_skip_words)
+        text_with_skip_words_matchable = CJK_WHITESPACE.sub("", text_with_skip_words)
     else:
         # Artifical word boundary
         text_no_skip_words += " "
@@ -298,7 +298,7 @@ def recognize_all(
                                 start=False,
                             )
                             if intents.settings.ignore_whitespace:
-                                text_with_skip_words_at_end = WHITESPACE.sub(
+                                text_with_skip_words_at_end = CJK_WHITESPACE.sub(
                                     "", text_with_skip_words_at_end
                                 )
                             else:
@@ -314,7 +314,7 @@ def recognize_all(
                                 end=False,
                             )
                             if intents.settings.ignore_whitespace:
-                                text_with_skip_words_at_start = WHITESPACE.sub(
+                                text_with_skip_words_at_start = CJK_WHITESPACE.sub(
                                     "", text_with_skip_words_at_start
                                 )
                             else:
@@ -477,7 +477,7 @@ def is_match(
         text = remove_skip_words(text, skip_words, ignore_whitespace)
 
     if ignore_whitespace:
-        text = WHITESPACE.sub("", text)
+        text = CJK_WHITESPACE.sub("", text)
     else:
         # Artifical word boundary
         text += " "

--- a/hassil/string_matcher.py
+++ b/hassil/string_matcher.py
@@ -36,7 +36,7 @@ from .models import (
 from .numbers import get_rbnf_engine
 from .trie import Trie
 from .util import (
-    WHITESPACE,
+    CJK_WHITESPACE,
     check_excluded_context,
     check_required_context,
     match_first,
@@ -194,9 +194,9 @@ def match_expression(
         leading_ws = 0
 
         if settings.ignore_whitespace:
-            # Remove all whitespace
-            chunk_text = WHITESPACE.sub("", chunk.text)
-            context_text = WHITESPACE.sub("", context.text)
+            # Remove whitespace between CJK characters only
+            chunk_text = CJK_WHITESPACE.sub("", chunk.text)
+            context_text = CJK_WHITESPACE.sub("", context.text)
         else:
             # Keep whitespace
             chunk_text = chunk.text

--- a/hassil/util.py
+++ b/hassil/util.py
@@ -16,6 +16,19 @@ WHITESPACE = re.compile(r"\s+")
 WHITESPACE_CAPTURE = re.compile(r"(\s+)")
 WHITESPACE_SEPARATOR = " "
 
+# Scripts without inter-word spaces (CJK ideographs, Japanese kana, Korean
+# hangul). When ``ignore_whitespace`` is set, whitespace is only removed
+# *between* two of these characters. Whitespace at a CJK/non-CJK boundary or
+# between non-CJK characters is preserved so that values like song titles
+# ("Taylor Swift") keep their internal spaces instead of being glued together.
+CJK = (
+    "一-鿿"  # CJK Unified Ideographs
+    "㐀-䶿"  # CJK Unified Ideographs Extension A
+    "぀-ヿ"  # Hiragana + Katakana
+    "가-힯"  # Hangul Syllables
+)
+CJK_WHITESPACE = re.compile(rf"(?<=[{CJK}])\s+(?=[{CJK}])")
+
 TEMPLATE_SYNTAX = re.compile(r".*[(){}<>\[\]|@].*")
 
 PUNCTUATION_STR_NO_PERIOD = "。,，?¿？؟!¡！;；:：’"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "hassil"
-version     = "3.10.0"
+version     = "3.10.1"
 license     = {text = "Apache-2.0"}
 description = "The Home Assistant Intent Language parser"
 readme      = "README.md"

--- a/tests/test_recognize.py
+++ b/tests/test_recognize.py
@@ -631,22 +631,24 @@ def test_recognize_all() -> None:
 
 
 def test_ignore_whitespace() -> None:
-    """Test option to ignore whitespace during matching."""
+    """Test option to ignore whitespace between CJK characters during matching."""
     yaml_text = """
-    language: "en"
+    language: "zh-TW"
     settings:
       ignore_whitespace: true
     intents:
       TestIntent1:
         data:
           - sentences:
-              - "run [the] test"
+              - "打開[大]燈"
     """
 
     with io.StringIO(yaml_text) as test_file:
         intents = Intents.from_yaml(test_file)
 
-    for sentence in ("runtest", "runthetest", "r u n t h e t e s t"):
+    # Whitespace between CJK characters is ignored, so all of these match a
+    # template written without spaces.
+    for sentence in ("打開燈", "打開大燈", "打 開 大 燈"):
         result = recognize(sentence, intents)
         assert result is not None, sentence
 
@@ -1500,25 +1502,36 @@ def test_wildcard_outside_word() -> None:
 def test_wildcard_outside_word_ignore_whitespace() -> None:
     """Test wildcard outside of a word when ignoring whitespace."""
     yaml_text = """
-    language: "en"
+    language: "zh-TW"
     settings:
       ignore_whitespace: true
     intents:
       Test:
         data:
           - sentences:
-              - "ab{test} cd"
+              - "播放{search_query}"
     lists:
-      test:
+      search_query:
         wildcard: true
     """
 
     with io.StringIO(yaml_text) as test_file:
         intents = Intents.from_yaml(test_file)
 
-    for sentence in ("abc123 cd", "abc123cd"):
+    # Whitespace *between* CJK characters is ignored on both sides.
+    for sentence in ("播放五月天", "播放 五月天", "播放 五 月 天"):
         result = recognize(sentence, intents)
         assert result is not None, f"{sentence} should match"
+        assert result.entities["search_query"].value == "五月天"
+
+    # Whitespace inside a non-CJK value is preserved (issue #276): the setting
+    # must not glue "Taylor Swift" into "TaylorSwift".
+    result = recognize("播放 Taylor Swift", intents)
+    assert result is not None
+    entity = result.entities["search_query"]
+    assert entity.value == "Taylor Swift"
+    assert entity.text == "Taylor Swift"
+    assert entity.text_clean == "Taylor Swift"
 
 
 def test_entity_metadata() -> None:


### PR DESCRIPTION
## Problem

`ignore_whitespace` strips **all** whitespace from the utterance (and template) before matching. This is required for CJK languages, which have no inter-word spaces, but it applies indiscriminately and corrupts non-CJK wildcard captures.

```python
# language: zh-TW, ignore_whitespace: true, sentence "播放{search_query}"
recognize("播放 Taylor Swift", intents).entities["search_query"].value
# -> 'TaylorSwift'   (want: 'Taylor Swift')
```

`value`, `text`, and `text_clean` were all affected. In `home-assistant/intents` this hits `zh-CN`, `zh-TW`, and `zh-HK` across wildcard slots like `search_query`, `todo_list_item`, `shopping_list_item`, `message`, and `zone` — song titles, to-do items, etc.

## Fix

Restrict stripping to whitespace **between two CJK characters** (ideographs, kana, hangul) via a new `CJK_WHITESPACE` pattern, applied at every `ignore_whitespace` stripping site so template and input normalisation stay symmetric.

| input | before | after |
|---|---|---|
| `播放 五 月 天` | `播放五月天` ✅ | `播放五月天` ✅ |
| `播放 Taylor Swift` | `播放TaylorSwift` ❌ | `播放 Taylor Swift` ✅ |
| `打開 大燈` | `打開大燈` ✅ | `打開大燈` ✅ |

Whitespace at a CJK/non-CJK boundary is preserved, which is harmless: wildcards already trim leading/trailing whitespace from their captures, so `在電視上播放 Taylor Swift` still yields `Taylor Swift`.

CJK ranges included: CJK Unified Ideographs + Extension A, Hiragana/Katakana, Hangul Syllables. CJK punctuation (`U+3000–303F`) is intentionally left out — it adds edge cases (U+3000 is itself whitespace) with no demonstrated need.

## Tests

`test_wildcard_outside_word_ignore_whitespace` previously only asserted a match was found; it now checks the captured value and adds a non-CJK regression case (`Taylor Swift`). Both `ignore_whitespace` tests now use CJK text — the actual use case — instead of English.

## Behaviour change

Non-CJK values that were previously glued are no longer glued. That is the intent, but it changes behaviour for `zh-CN`/`zh-TW`/`zh-HK`, so this is versioned as 3.10.1.

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)